### PR TITLE
3B-G04-W008-PR01. Dynamic Page Titles

### DIFF
--- a/app/(auth)/login/layout.tsx
+++ b/app/(auth)/login/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "ARISE | Login",
+  description: "Sign in to your ARISE account.",
+};
+
+export default function LoginLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/(auth)/register/layout.tsx
+++ b/app/(auth)/register/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "ARISE | Register",
+  description: "Create a new ARISE account.",
+};
+
+export default function RegisterLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/(main)/direction/page.tsx
+++ b/app/(main)/direction/page.tsx
@@ -1,3 +1,10 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'ARISE | Direction',
+  description: 'Get directions to various locations on campus, including buildings, facilities, and points of interest.',
+}
+
 export default function DirectionPage() {
     return (
     <div className="w-full h-full bg-emerald-400">

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -2,32 +2,36 @@
 
 import "../globals.css";
 import Sidebar from "../components/Sidebar";
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname } from "next/navigation";
+import { useEffect } from "react";
 
 export default function MainLayout({
   children,
-}: {
+}: Readonly<{
   children: React.ReactNode;
-}) {
+}>) {
   const pathname = usePathname();
-  const router = useRouter();
 
   const formatBuilding = (name: string) => {
     if (name === "digicampus") return "DigiCampus";
     if (name === "maincampus") return "Main Campus";
-    return name.toUpperCase(); // gd1 → GD1
+    
+    // Check if it's gd1, gd2, etc., and turn it into GD 1, GD 2
+    if (name.startsWith("gd")) {
+      return `GD ${name.replace("gd", "")}`;
+    }
+    
+    return name.toUpperCase();
   };
 
-  //Dynamic title based on route
-  const getTitle = () => {
-
+  const getPageName = () => {
     // 3D MAP
     if (pathname.startsWith("/map3d")) {
       const parts = pathname.split("/");
       const building = parts[2];
 
       if (building) {
-        return `3D Map - ${formatBuilding(building)}`;
+        return formatBuilding(building);
       }
 
       return "3D Map";
@@ -36,39 +40,46 @@ export default function MainLayout({
     if (pathname.startsWith("/direction")) return "Direction";
     if (pathname.startsWith("/profile")) return "Profile";
 
-    return "ARISE";
+    return "";
   };
 
-  //Hide sidebar on homepage
+  // Logic specifically for the browser tab title
+  const getTabTitle = () => {
+    const pageName = getPageName();
+    return pageName ? `ARISE | ${pageName}` : "ARISE";
+  };
+
+  // Set dynamic page title
+  useEffect(() => {
+    document.title = getTabTitle();
+  }, [pathname]);
+
+  // Hide sidebar on homepage
   if (pathname === "/") {
     return <>{children}</>;
   }
 
   return (
     <div className="flex w-screen h-screen overflow-hidden">
-
       <Sidebar />
 
       {/* RIGHT SIDE */}
       <div className="flex-1 flex flex-col">
 
         {/* TOP BAR */}
-        <div className="h-[80px] flex items-center justify-between px-8 
+        <div className="h-20 flex items-center justify-between px-8 
           bg-black/30 backdrop-blur-xl border-b border-white/10 text-white">
 
           {/* LEFT: PAGE TITLE */}
           <h1 className="text-xl font-semibold tracking-wide">
-            {getTitle()}
+            {getPageName() || "ARISE"}
           </h1>
 
           {/* RIGHT: (future area) */}
           <div className="flex items-center gap-4">
-
-            {/* Placeholder circle (profile/avatar soon) */}
             <div className="w-9 h-9 rounded-full bg-white/10 border border-white/20 flex items-center justify-center text-sm">
               U
             </div>
-
           </div>
         </div>
 

--- a/app/(main)/map3d/digicampus/page.tsx
+++ b/app/(main)/map3d/digicampus/page.tsx
@@ -1,3 +1,10 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'ARISE | DigiCampus',
+  description: 'Explore the 3D map of DigiCampus, view building layouts, and find your way around with ease.',
+}
+
 export default function DigicampusPage() {
     return (
     <div className="w-full h-full bg-indigo-950">

--- a/app/(main)/map3d/gd1/page.tsx
+++ b/app/(main)/map3d/gd1/page.tsx
@@ -1,3 +1,10 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'ARISE | GD 1',
+  description: 'Explore the 3D map of GD1, view building layouts, and find your way around with ease.',
+}
+
 export default function GdOnePage() {
     return (
     <div className="w-full h-full bg-lime-950">

--- a/app/(main)/map3d/gd2/page.tsx
+++ b/app/(main)/map3d/gd2/page.tsx
@@ -1,3 +1,10 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'ARISE | GD 2',
+  description: 'Explore the 3D map of GD2, view building layouts, and find your way around with ease.',
+}
+
 export default function GdTwoPage() {
     return (
     <div className="w-full h-full bg-pink-700">

--- a/app/(main)/map3d/gd3/page.tsx
+++ b/app/(main)/map3d/gd3/page.tsx
@@ -1,3 +1,10 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'ARISE | GD 3',
+  description: 'Explore the 3D map of GD3, view building layouts, and find your way around with ease.',
+}
+
 export default function GdThreePage() {
     return (
     <div className="w-full h-full bg-red-700">

--- a/app/(main)/map3d/maincampus/page.tsx
+++ b/app/(main)/map3d/maincampus/page.tsx
@@ -1,3 +1,10 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'ARISE | Main Campus',
+  description: 'Explore the 3D map of Main Campus, view building layouts, and find your way around with ease.',
+}
+
 export default function MaincampusPage() {
     return (
     <div className="w-full h-full bg-blue-600">

--- a/app/(main)/profile/layout.tsx
+++ b/app/(main)/profile/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "ARISE | Profile",
+  description: "Profile Account",
+};
+
+export default function RegisterLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/(main)/profile/page.tsx
+++ b/app/(main)/profile/page.tsx
@@ -37,9 +37,12 @@ export default function ProfilePage() {
   return () => unsubscribe();
 }, []);
 
+  useEffect(() => {
+    document.title = 'ARISE | Profile';
+  }, );
 
   return (
-    <div className="w-full h-full bg-gradient-to-br from-[#0f172a] via-[#1e293b] to-[#020617] p-6 overflow-y-auto">
+    <div className="w-full h-full bg-linear-to-br from-[#0f172a] via-[#1e293b] to-[#020617] p-6 overflow-y-auto">
 
       {/* 🔷 PROFILE HEADER */}
       <div className="w-full bg-slate-800/80 border border-slate-700 shadow-md rounded-xl p-6 mb-6 flex items-center gap-4">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,10 @@
 import "./globals.css";
 
 export const metadata = {
-  title: "ARISE",
+  title: {
+    default: "ARISE",
+    template: "%s",
+  },
   description: "Campus System",
 };
 


### PR DESCRIPTION
## Summary
- Added a layout and metadata for login, register, and direction pages updated page titles for 3D map and profile pages
- To ensures titles like ARISE | Login are baked into the HTML on the server, preventing them from reverting to a generic title or being overridden by client-side hooks.
- Fixed the issue for profile page title when navigating the page and when you reload the profile page the title went back to being "ARISE" instead of "ARISE | Profile"

## Changes
- Root Layout: Set up a title template so we don't have to hardcode "ARISE |" on every single page.
- Auth & Directions: Created layout.tsx files for Login, Register, and Directions to push the titles from the server.
- Cleanup: Pulled out the useEffect title logic in the client pages to stop them from fighting with the server metadata.
- 3D Map & Profile: Synced these titles to match the new format.
- Added a profile layout and metadata for user profile page

## Checklist
- [x] Code follows project guidelines.
- [x] Tested locally and works as expected.
- [x] No breaking changes to existing features.
